### PR TITLE
[fix] incorrect JRuby version detection

### DIFF
--- a/lib/eventbox.rb
+++ b/lib/eventbox.rb
@@ -18,8 +18,7 @@ class Eventbox
   class MultipleResults < RuntimeError; end
   class AbortAction < RuntimeError; end
 
-  if RUBY_ENGINE=='jruby' && RUBY_VERSION.split(".").map(&:to_i).pack("C*") < [9,2,1,0].pack("C*") ||
-      RUBY_ENGINE=='truffleruby'
+  if RUBY_ENGINE=='jruby' && JRUBY_VERSION < '9.2.1.0' || RUBY_ENGINE=='truffleruby'
     # This is a workaround for bug https://github.com/jruby/jruby/issues/5314
     # which was fixed in JRuby-9.2.1.0.
     class Thread < ::Thread


### PR DESCRIPTION
RUBY_VERSION reports Ruby compatibility version e.g. '2.5.0' for 9.2
alternatively JRuby always has the `JRUBY_VERSION` constant around