### PR TITLE
CI: Add necessary rubyinstaller option

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ install:
   - ps: |
       if ($env:RUBYDOWNLOAD -ne $null) {
         $(new-object net.webclient).DownloadFile("https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-head/rubyinstaller-head-$env:RUBYDOWNLOAD.exe", "$pwd/ruby-setup.exe")
-        cmd /c ruby-setup.exe /verysilent /dir=C:/Ruby$env:ruby_version
+        cmd /c ruby-setup.exe /verysilent /currentuser /dir=C:/Ruby$env:ruby_version
       }
   - ruby --version
   - gem --version


### PR DESCRIPTION
Otherwise newer rubyinstaller versions block endlessly in CI.